### PR TITLE
Add Replicate API links for PuLID and Flux PuLID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PuLID
 
 ### :open_book: PuLID: Pure and Lightning ID Customization via Contrastive Alignment
-> [![arXiv](https://img.shields.io/badge/arXiv-Paper-<COLOR>.svg)](https://arxiv.org/abs/2404.16022) [![xl](https://img.shields.io/badge/🤗-HuggingFaceDemo-orange)](https://huggingface.co/spaces/yanze/PuLID) [![flux](https://img.shields.io/badge/🤗-PuLID_FLUX_demo-orange)](https://huggingface.co/spaces/yanze/PuLID-FLUX) <br>
+> [![arXiv](https://img.shields.io/badge/arXiv-Paper-<COLOR>.svg)](https://arxiv.org/abs/2404.16022) [![xl](https://img.shields.io/badge/🤗-HuggingFaceDemo-orange)](https://huggingface.co/spaces/yanze/PuLID) [![flux](https://img.shields.io/badge/🤗-PuLID_FLUX_demo-orange)](https://huggingface.co/spaces/yanze/PuLID-FLUX) <br> [![Replicate](https://replicate.com/zsxkib/pulid/badge)](https://replicate.com/zsxkib/pulid) [![Replicate](https://replicate.com/zsxkib/flux-pulid/badge)](https://replicate.com/zsxkib/flux-pulid)<br>
 > Zinan Guo*, Yanze Wu*✝, Zhuowei Chen, Lang Chen, Qian He <br>
 > (*Equal Contribution, ✝Corresponding Author) <br>
 > ByteDance Inc <br>
@@ -21,6 +21,7 @@ We will actively update and maintain this repository in the near future, so plea
 - [x] Local gradio demo is ready now
 - [x] Online HuggingFace demo is ready now [![flux](https://img.shields.io/badge/🤗-PuLID_FLUX_demo-orange)](https://huggingface.co/spaces/yanze/PuLID-FLUX)
 - [x] We have optimized the codes to support consumer-grade GPUS, and now **PuLID-FLUX can run on a 16GB graphic card**. Check the details [here](https://github.com/ToTheBeginning/PuLID/blob/main/docs/pulid_for_flux.md#local-gradio-demo)
+- [x] Online Replicate demo is ready now [![Replicate](https://replicate.com/zsxkib/flux-pulid/badge)](https://replicate.com/zsxkib/flux-pulid)
 
 
 Below results are generated with PuLID-FLUX.
@@ -70,7 +71,8 @@ and we will include them in this list.
 
 #### Online Demo
 - **Colab**: https://github.com/camenduru/PuLID-jupyter provided by [camenduru](https://github.com/camenduru)
-- **Replicate**: https://replicate.com/zsxkib/pulid provided by [zsxkib](https://replicate.com/zsxkib)
+- **Replicate (PuLID)**: https://replicate.com/zsxkib/pulid provided by [zsxkib](https://github.com/zsxkib)
+- **Replicate (PuLID-FLUX)**: https://replicate.com/zsxkib/flux-pulid provided by [zsxkib](https://github.com/zsxkib)
 
 #### ComfyUI
 - https://github.com/cubiq/PuLID_ComfyUI provided by [cubiq](https://github.com/cubiq), native ComfyUI implementation


### PR DESCRIPTION
# Add Replicate API links for PuLID and Flux PuLID

Hello again, I have added FLUX-PuLID to Replicate
<img width="490" alt="image" src="https://github.com/user-attachments/assets/28436968-a7f8-485c-81de-b33292f60064">

## Changes

This PR adds links to the Replicate API for both the original PuLID and the new Flux PuLID models in the readme. These changes will help users easily access and use the models through Replicate's platform.

## Additions

1. Added a link to the original PuLID model on Replicate: https://replicate.com/zsxkib/pulid
2. Added a link to the new Flux PuLID model on Replicate: https://replicate.com/zsxkib/flux-pulid

## Benefits

- Easier access: Users can now quickly find and use both PuLID models through Replicate.
- Increased visibility: Adding these links will help more people discover and use the PuLID models.
- No code changes: This PR only updates the readme, keeping the main codebase unchanged.

## Notes

- The Flux PuLID model includes some improvements, such as the ability to generate multiple images at once (using `num_outputs`).
- The code for the Flux PuLID API is in a separate branch on my fork: https://github.com/zsxkib/PuLID/tree/cog-flux-pulid

I'm happy to make any necessary changes to get this PR merged. Please let me know if you need any additional information or have any questions.